### PR TITLE
clarify questions in 1-tof-sensor.ipynb

### DIFF
--- a/dd21-sensors-tof/notebooks/1-tof-sensor.ipynb
+++ b/dd21-sensors-tof/notebooks/1-tof-sensor.ipynb
@@ -40,7 +40,7 @@
     "estimate. ROS requires all distances to be in meters.  \n",
     "\n",
     "### Questions\n",
-    "1. Look on the data sheet for the ToF sensor on your drone, you can find it [here](https://cdn-learn.adafruit.com/assets/assets/000/037/547/original/en.DM00279086.pdf).  You will be using the recommended Python library to read data from the ToF sensor.  In what units does it output distances?\n",
+    "1. You will be using [the recommended Python library](https://docs.circuitpython.org/projects/vl53l0x/en/latest/) to read data from the ToF sensor. In what units does it output the measured range?\n",
     "\n"
    ]
   },
@@ -51,7 +51,7 @@
    "source": [
     "# Activity: Using your Time-of-flight Sensor\n",
     "\n",
-    "In this part of the project, you will learn how to estimate the drone's height using its time-of-flight sensor. The drone is equipped with a [VL53L0X](https://learn.adafruit.com/adafruit-vl53l0x-micro-lidar-distance-sensor-breakout), which is used for estimating the distance from the drone to the ground-plane. The sensor outputs a digital signal containing the distance from the sensor and read in by the Raspberry Pi via the GPIO pin using the associated [Python library](https://docs.circuitpython.org/projects/vl53l0x/en/latest/). The voltage value corresponds to distance, but we are going to need to do some work to convert it to real-world units.\n",
+    "In this part of the project, you will learn how to estimate the drone's height using its time-of-flight sensor. The drone is equipped with a [VL53L0X distance sensor](https://learn.adafruit.com/adafruit-vl53l0x-micro-lidar-distance-sensor-breakout), which is used for estimating the distance from the drone to the ground. The sensor outputs a digital signal which is read in by the Raspberry Pi via I2C communication using the associated [Python library](https://docs.circuitpython.org/projects/vl53l0x/en/latest/).\n",
     "\n",
     "**Activity**\n",
     "\n",


### PR DESCRIPTION
Question 1 is asking about what units the ToF sensor library returns readings in. The answer to this question is on this page https://docs.circuitpython.org/projects/vl53l0x/en/latest/api.html#adafruit_vl53l0x.VL53L0X.range, and I can't find the answer in the datasheet, so I think the question would be made a lot more straightforward if more of the links to information about the sensor could be given along with the question. There's also a mention to reading voltages which is incorrect now that we've moved from the old IR sensor to the TOF sensor.

