### PR TITLE
Update readme link and correct training notebook model inspection instruction

### DIFF
--- a/object-detection/README.md
+++ b/object-detection/README.md
@@ -7,7 +7,7 @@
 # About these activities
 
 This learning experience will take you through the process of collecting data from the Duckietown simulator and formatting it to be used to train a neural network to perform object detection using the robot's camera image. 
-We will use one of the most popular object detection neural networks, called [YOLO (v5)](https://docs.ultralytics.com/). You will also have to integrate this trained model into the autonomy stack. For now we will just stop whenever an object (duckie) is detected in the road. 
+We will use one of the most popular object detection neural networks, called [YOLO (v5)](https://docs.ultralytics.com/yolov5/). You will also have to integrate this trained model into the autonomy stack. For now we will just stop whenever an object (duckie) is detected in the road. 
 
 This learning experience is provided by the Duckietown team and can be run on Duckiebots. Visit us at the 
 [Duckietown Website](https://www.duckietown.com) for more learning materials, documentation, and demos.

--- a/object-detection/notebooks/03-Training/training.ipynb
+++ b/object-detection/notebooks/03-Training/training.ipynb
@@ -156,6 +156,8 @@
     "* When prompted the notification below, click \"*Connect to Google Drive*\"\n",
     "    ![](../../assets/images/colab_instr_4_connect_gdrive.png)\n",
     "\n",
+    "***NOTE:*** If you want to view the training statistics and artefacts, do NOT close the Colab notebook after training. Follow the instructions in the following **Debugging and Model Inspection** section to examine these contents.\n",
+    "\n",
     "Now follow the instructions in the Colab notebook. \n",
     "For reference, on google colab, training with the default settings takes a few minutes.\n"
    ]
@@ -193,7 +195,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One you have finished training on Colab, there are a bunch of interesting outputs that will get generated during the training process that can be helpful for you to look at. Navigate to your google drive folder and then go into the `yolov5` directory. Then navigation to `runs/train/expX/` where `X` is incremented each time you train. In here you can see things like your PR curve, e.g.:\n",
+    "One you have finished training on Colab, there are a bunch of interesting outputs that will get generated during the training process that can be helpful for you to look at.\n",
+    "\n",
+    "* During the Colab notebook execution, a session temporary workspace directory has been created. The path is shown in a cell output, similar as `Session workspace created at: /tmp/tmpxe3g50sz`\n",
+    "* Navigate to the workspace folder in the left Navigation Menu (on Colab), in the Files tree. (You might need to click the `..` to go up to `/`)\n",
+    "* After locating the `/tmp/...` workspace folder, go into the `yolov5` directory inside.\n",
+    "* Then navigate to `runs/train/expX/` where `X` is incremented each time you train.\n",
+    "* If you want to save these results, using the left Navigation Menu's Files tree, drag the folders/files you want to keep, to the `/content/drive/MyDrive` directory. Then you will be able to find them in your Google Drive even after closing the Colab session.\n",
+    "\n",
+    "In here you can see things like your PR curve, e.g.:\n",
     "\n",
     "<img src=\"../../assets/images/PR_curve.png\" alt=\"PR Curve\" width=\"50%\">\n",
     "\n",


### PR DESCRIPTION
Summary:
* readme: existing link points to Yolov8, changed to point to yolov5
* training notebook:
  * tmp folders were created for faster training
  * but the intermediate files/model inspection are lost after colab session ends
  * updated instruction to point to correct file locations, and how to save folder/file from `/tmp` to GDrive after exit