### PR TITLE
moved NN intro NB to lx-recipe, update link

### DIFF
--- a/object-detection/notebooks/01-CNN/cnn.ipynb
+++ b/object-detection/notebooks/01-CNN/cnn.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Getting Started with Colab\n",
     "\n",
-    "If you are unfamiliar with CNNs, we have made a **Google Colab Notebook** for you to get started: [Intro to neural networks with Duckietown](https://colab.research.google.com/drive/12SN3t9bQ60hbzR-qiKkaXjyYRa_jjroT). **This notebook is completely optional.**\n",
+    "If you are unfamiliar with CNNs, we have made a **Google Colab Notebook** for you to get started: [Intro to neural networks with Duckietown](https://colab.research.google.com/github/duckietown/duckietown-lx-recipes/blob/mooc2022/object-detection/assets/colab/dt_intro_nn_with_pytorch.ipynb). **This notebook is completely optional.**\n",
     "\n",
     "To access the tutorial:\n",
     "1) You should first click on the link to open up the notebook on Colab. \n",


### PR DESCRIPTION
The link leads to the correct new location of the notebook:

![image](https://github.com/duckietown/duckietown-lx/assets/10885835/1dd5370b-8ce1-4312-8ce5-521326eaa4b9)
