### PR TITLE
Change unit test target in solution notebook

### DIFF
--- a/modcon/notebooks/04-Odometry/solutions_odometry_activity.ipynb
+++ b/modcon/notebooks/04-Odometry/solutions_odometry_activity.ipynb
@@ -280,11 +280,7 @@
    "source": [
     "from tests.unit_test import UnitTestOdometry\n",
     "\n",
-    "from solution.odometry_activity import pose_estimation\n",
-    "\n",
-    "# This function has hardcoded values (bad practice!) to test the `pose_estimation` function above.\n",
-    "# The test will be successful if you get a circle. Anything short of a circle.. probably best to go back and check.\n",
-    "\n",
+    "# with the above sample solution, a circle should be shown\n",
     "UnitTestOdometry(R, baseline_wheel2wheel, pose_estimation)"
    ]
   },


### PR DESCRIPTION
In the `04-Odometry` folder
* the `odometry_activity.ipynb` runs a unit test against the student's implementation of `pose_estimation(...)` ([here](https://github.com/duckietown/duckietown-lx/blob/7f431d61fd8d326c5f59cae3a3afa0421bf04536/modcon/notebooks/04-Odometry/odometry_activity.ipynb#L467))
* the `solution_odometry_activity.ipynb` should run the unit test against the ***provided solution*** version in that notebook

Instead, the student version is imported again ([here](https://github.com/duckietown/duckietown-lx/blob/7f431d61fd8d326c5f59cae3a3afa0421bf04536/modcon/notebooks/04-Odometry/solutions_odometry_activity.ipynb#L283)) in the `solution_...ipynb`. This PR corrects this.