### PR TITLE
Update odometry_activity.ipynb

### DIFF
--- a/modcon/notebooks/04-Odometry/odometry_activity.ipynb
+++ b/modcon/notebooks/04-Odometry/odometry_activity.ipynb
@@ -215,8 +215,17 @@
     "rotation_wheel_left = None # total rotation of left wheel \n",
     "rotation_wheel_right = None # total rotation of right wheel \n",
     "\n",
-    "print(f\"The left wheel rotated: {np.rad2deg(rotation_wheel_left)} degrees\")\n",
-    "print(f\"The right wheel rotated: {np.rad2deg(rotation_wheel_right)} degrees\")"
+    if rotation_wheel_left is not None:
+       left_degrees = np.rad2deg(rotation_wheel_left)
+    else:
+       left_degrees = "unknown"
+    if rotation_wheel_right is not None:
+       right_degrees = np.rad2deg(rotation_wheel_right)
+    else:
+       right_degrees = "unknown"
+     "\n",
+    "print(f\"The left wheel rotated: (left degrees)} degrees\")\n",
+    "print(f\"The right wheel rotated:(right degrees)} degrees\")"
    ]
   },
   {


### PR DESCRIPTION
rotation_wheel_left and rotation_wheel_right are set to None, and when trying to use np.rad2deg on them that which requires numerical input. we get an error so this change fixes it.