### PR TITLE
Update particle-filter.ipynb

### DIFF
--- a/state-estimation/notebooks/02-particle-filter/particle-filter.ipynb
+++ b/state-estimation/notebooks/02-particle-filter/particle-filter.ipynb
@@ -250,7 +250,7 @@
     "    # get state estimate by taking the mean of the resampled particles (excluding the randomly sampled ones)\n",
     "    xs = []\n",
     "    ys = []\n",
-    "    for p in particles[:int(num_particles)]:\n",
+    "    for p in particles[:int(num_particles*alpha)]:\n",
     "        xs.append(p.state[0])\n",
     "        ys.append(p.state[1])\n",
     "    estimated_x = np.mean(xs)\n",


### PR DESCRIPTION
Fix correct number of used particles for state estimation. Before all particles were used, even  randomly sampled. In this pr only resampled particles used.